### PR TITLE
[Daily] 두 큐 합 같게 만들기 / level 2

### DIFF
--- a/W3/seo/두 큐 합 같게 만들기.js
+++ b/W3/seo/두 큐 합 같게 만들기.js
@@ -1,0 +1,55 @@
+/*
+ * @url https://school.programmers.co.kr/learn/courses/30/lessons/118667
+ * @date 23-12-04
+ */
+
+/**
+ * @param {number[]} queue1
+ * @param {number[]} queue2
+ * @returns {number}
+ */
+function solution(queue1, queue2) {
+	let sumQ1 = queue1.reduce((acc, cur) => acc + cur, 0);
+	let sumQ2 = queue2.reduce((acc, cur) => acc + cur, 0);
+
+	if ((sumQ1 + sumQ2) % 2 === 1) return -1;
+
+	const maxLoop = queue1.length * 3;
+	let [q1idx, q2idx] = [0, 0];
+
+	for (let i = 0; i < maxLoop; i++) {
+		if (sumQ1 === sumQ2) return i;
+
+		if (sumQ1 > sumQ2) {
+			const popQ1Val = queue1[q1idx++];
+			queue2.push(popQ1Val);
+			sumQ2 += popQ1Val;
+			sumQ1 -= popQ1Val;
+			continue;
+		}
+
+		if (sumQ1 < sumQ2) {
+			const popQ2Val = queue2[q2idx++];
+			queue1.push(popQ2Val);
+			sumQ1 += popQ2Val;
+			sumQ2 -= popQ2Val;
+			continue;
+		}
+	}
+
+	return -1;
+}
+
+/*
+ * 문제 풀이 흐름
+ * 1. 큐1 , 큐2 의 값을 더한 각각의 변수 -> sumQ1, sumQ2
+ * 2. sum 변수가 더 큰 q에서 더 작은 q로 무조건 보내야 함
+ * 3. 아무리 작업해도 안되는 경우 측정
+ * 		- try1 : 경우의 수 구하기. length ** 2 해서 maxLoop 측정
+ * 				=> (signal: aborted (core dumped)) -> 산술 오버플로우 발생 -> Big int 안먹힘
+ * 		- try2 : queue1.length * 2 + 1 - why?..
+ *				=> [1,1,1] [1,5,1]  두개의 큐가 들어올 경우 총 9번 탐색을 해야 결과 도출 가능
+ * 				=> 투포인터로 생각해보면 이해가 좀 더 쉬움
+ *				=> n = len(q1) + len(q2) * 2
+ *				=> 프로그래머스 테케는 maxLoop를 len*3만 해도 정답처리된다. 왜인지는 모르겠다.
+ */


### PR DESCRIPTION
## Daily PS Docs

> 1일 1문제를 풀고 PR시 사용하는 템플릿입니다. <br />
> 답하기 어려운 질문이 있다면 넘어가도 좋습니다.

- 문제 ULR: https://school.programmers.co.kr/learn/courses/30/lessons/118667

### 1. **문제 설명**

> 주어진 입력과 요구되는 출력에 대해 간략히 설명해주세요.

- 입력 : number 로 이루어진 배열 두개 . 각각 queue1, queue2. 둘의 배열 길이는 같습니다.
 
- 출력 :  두 큐의 요소의 합이 동일할때까지 입출력을 반복한 횟수. 입출력은 큐의 속성을 따릅니다. 또한, 두 큐의 합이 같게 만들 수 없는 경우 -1을 출력합니다.

### 2. **문제의 엣지 케이스**

> 해당 문제가 가질 수 있는 극단적인 케이스에 대해 적어주세요.

``` js
// 극단적 케이스 예시
const queue1 = [1,1,1];
const queue2 = [1,5,1];
```
- 만약, 두 큐의 합을 동일하게 만들 수 있는 배열이 주어졌을 때 모든 요소 중 가장 큰 요소가 한 배열의 오른쪽 두번째 칸에 위치한 경우, 두 배열의 합을 같게 만들 수 있는지 판단하기 위해선 `배열의 길이 * 2` 만큼의 탐색이 필요합니다.
- 위의 예시의 경우 총 **9번의 탐색**이 필요합니다.

### 3. **사용한 데이터 구조와 알고리즘**

> 문제를 풀기 위해 사용한 주요한 데이터 구조 및 알고리즘에 대해 적어주세요.

- Greedy, 큐

### 4. **의사 코드**

> 구현한 코드를 단계별로 설명해 주세요.

1. 1. 큐1 , 큐2 의 값을 더해 `sumQ1`, `sumQ2`에 할당 합니다.
2. 두 수를 더한 것이 홀수 일 경우, 두 큐의 합을 같게 만들 수 없으니 예외처리를 해줍니다.
3. 최대 반복 횟수 - `queue.length * 4` 를 설정하고 해당 횟수만큼 loop를 돌립니다. 
    (주어진 테케에서는  `queue.length * 3` 으로 해도 통과가 되던데 왜 그런지는 모르겠어요)
4. JavaScript의 shift연산자는 비용이 크기 때문에, 이를 대신할 수 있는 각 q의 idx를 대신 사용합니다.
5. 반복문을 돌며  `sumQ1`, `sumQ2` 중 더 큰 쪽에서 q의 원소를 가져와 작은쪽으로 입력합니다.
6. 이때 `sumQ1`, `sumQ2` 의 크기가 같다면 해당 루프의 반복 횟수를 출력합니다.
7. 루프를 다 돌았을 경우 -1을 출력합니다.


### 5. **시간 복잡도, 공간 복잡도 측정**

> 구현한 코드의 시간 복잡도와 공간 복잡도를 그 이유와 함께 적어주세요.

- 시간 복잡도 , 공간 복잡도:  `O(n)`
    -  reduce문 2개, for 문 1개 
    - 이때 for문을 돌며 queue의 각 길이가 증가. 

### 6. **최적화**

> 구현한 코드에서 최적화 할 수 있는 부분이 있을까요? 있다면 어떻게 수정되어야 할까요?

- q에 직접 push하는게 아닌 이것도 포인터 인덱스를 이용해 구현했다면.. 공간 복잡도를 O(1)로 줄일 수 있을 것 같다는 생각이 드네요.

### 7. **배운 점 또는 추가로 생각해볼 점**

> 인사이트에 대해 간략히 적어주세요.

- 탐색 범위 설정하는 것을 좀 더 신중히 접근해야 할 것 같아요. 처음에 경우의 수를 설정하면 되겠지 해서 `length^2`로 하니... 11번이랑 28번 테케만 계속 틀렸어요. 😢  문제를 풀 때,,, 최악의 상황을 가정하고 시뮬레이션 돌려보는 연습이 많이 필요할 것 같아요. 

- 참고 유튜브 : https://www.youtube.com/watch?v=rntT16XgqRc
