### PR TITLE
[Daily] 두 큐 합 같게 만들기 / level 2

### DIFF
--- a/W3/Austin/daily/두 큐 합 같게 만들기.js
+++ b/W3/Austin/daily/두 큐 합 같게 만들기.js
@@ -1,0 +1,45 @@
+/*
+ * @url https://school.programmers.co.kr/learn/courses/30/lessons/118667
+ * @date 23-12-05
+ */
+function solution(queue1, queue2) {
+	const oroginalLength = queue1.length;
+
+	let queue1Sum = queue1.reduce((a, b) => a + b);
+	let queue2Sum = queue2.reduce((a, b) => a + b);
+
+	let count = 0;
+	let queue1Start = 0;
+	let queue2Start = 0;
+
+	while (queue1Sum !== queue2Sum) {
+		while (queue1Sum > queue2Sum) {
+			const queue1FirstValue = queue1[queue1Start];
+			queue2Sum += queue1FirstValue;
+			queue2.push(queue1FirstValue);
+			queue1Sum -= queue1FirstValue;
+			queue1Start += 1;
+			count += 1;
+		}
+		// 한쪽 큐가 전부 다른쪽으로 넘어갔을 경우
+		if (queue1Start === oroginalLength * 2) {
+			count = -1;
+			break;
+		}
+
+		while (queue1Sum < queue2Sum) {
+			const queue2FirstValue = queue2[queue2Start];
+			queue1Sum += queue2FirstValue;
+			queue1.push(queue2FirstValue);
+			queue2Sum -= queue2FirstValue;
+			queue2Start += 1;
+			count += 1;
+		}
+		if (queue2Start === oroginalLength * 2) {
+			count = -1;
+			break;
+		}
+	}
+
+	return count;
+}


### PR DESCRIPTION
### 1. **문제 설명**

> 주어진 입력과 요구되는 출력에 대해 간략히 설명해주세요.

- 입력 : 길이가 같은 2개의 큐

- 출력 :  각 큐의 원소 합을 같게 만들기 위해 필요한 작업의 최소 횟수

### 2. **문제의 엣지 케이스**

> 해당 문제가 가질 수 있는 극단적인 케이스에 대해 적어주세요.

-

### 3. **사용한 데이터 구조와 알고리즘**

- 투포인터

### 4. **의사 코드**


- 초기 상태는 아래와 같다

```tsx
 1 , 2 , 1 , 2  (합:6)
(p)

 1 , 10 , 1 , 2 (합:14)
(p)
```

둘 중에서 **`합이 큰 곳을 빼서 작은 곳으로 옮겨줘야 하므로`**

**합이 컸던 배열이 작았던 부분보다 더이상 크지 않을 때까지 아래의 과정을 진행한다**

- 큰 쪽의 포인터 부분을 작은 쪽의 큐에 push
- 작은 쪽의 큐에 push 된 만큼 더해주고 , 큰 쪽의 큐에는 넘어간 만큼 빼준다
- 그리고 큰 쪽에서 포인터를 다음으로 옮겨준다
    
    **`이제 큰 부분의 배열은 옮겨진 포인터부터 시작하게 된다` (=shift를 사용하지 않기 위함이다)**
    

```tsx
 1 , 2 , 1 , 2  , 1 (6+1)
(p)

 1 , 10 , 1 , 2 (14-1)    // 이제 이 배열은 10 1 2 가 되는 것이다
     (p)
```

이런 과정을 반복하면 아래과 같다

```tsx
 1 , 2 , 1 , 2  , 1 , 10 (6+1+10)
(p)

 1 , 10 , 1 , 2 (14-1-10)
           (p)
```

```tsx
 1 , 2 , 1 , 2  , 1 , 10 (6+1+10-1)
    (p)

 1 , 10 , 1 , 2 , 1 (14-1-10+1)
           (p)
```

이렇게 서로의 배열의 값을 주고받고를 진행하다가 2개의 합이 같으면 while문이 끝나는 것이다

그렇지만 3번째 테스트케이스처럼 답이 나오지 않는 구간의 경우 무한루프를 돌게 되므로 특정 조건을 추가해준다

<br>
<br>

만약 큐의 길이만큼 전부 다른 쪽으로 넘어갔는데도 답이 안 나온다면 

그건 정답이 나올 수 없는 테스트 케이스인 것이다 

<br>

그래서 둘 중 하나의 포인터라도 길이*2 만큼 진행했다면 -1을 리턴한다

**`하나의 큐가 전부 다른 큐로 넘어갔을때를 의미한다` >> 2개의 큐가 동일한 값이 나올 수 없음**

```tsx
1 , 1
1 , 5

>>>

1 , 1 , 1 , 5 // 길이가 4 >> -1리턴
[ ]
```



### 5. **시간 복잡도, 공간 복잡도 측정**

> 구현한 코드의 시간 복잡도와 공간 복잡도를 그 이유와 함께 적어주세요.

1.

### 6. **최적화**

> 구현한 코드에서 최적화 할 수 있는 부분이 있을까요? 있다면 어떻게 수정되어야 할까요?

-  

### 7. **배운 점 또는 추가로 생각해볼 점**

> 인사이트에 대해 간략히 적어주세요.

-  큐의 길이가 30만 이라는 것을 보고 바로 그리디나 투포인터같은 로직을 생각했어야 했는데 그러질 못해서 시간이 오래걸렸네요... 항상 문제의 제한사항을 기반으로 로직을 도출해야하는 능력을 키워야 할 것 같습니다
